### PR TITLE
Dismissing order name edit panel if user clicks anywhere outside it - fixed Issue #90

### DIFF
--- a/client/app/scripts/controllers/store-landing.js
+++ b/client/app/scripts/controllers/store-landing.js
@@ -10,9 +10,9 @@
 angular.module('ShoppinPalApp')
   .controller('StoreLandingCtrl', [
     '$scope', '$anchorScroll', '$location', '$state', '$filter', '$sessionStorage', /* angular's modules/services/factories etc. */
-    'UserModel', 'LoopBackAuth', 'StoreModel', 'ReportModel', /* shoppinpal's custom modules/services/factories etc. */
+    'UserModel', 'LoopBackAuth', 'StoreModel', 'ReportModel', 'deviceDetector', /* shoppinpal's custom modules/services/factories etc. */
     function($scope, $anchorScroll, $location, $state, $filter, $sessionStorage,
-             UserModel, LoopBackAuth, StoreModel, ReportModel)
+             UserModel, LoopBackAuth, StoreModel, ReportModel, deviceDetector)
     {
       $scope.storeName = $sessionStorage.currentStore.name;
 
@@ -21,6 +21,31 @@ angular.module('ShoppinPalApp')
       $scope.sortedOrder = [];
       $scope.reportLists = [];
       $scope.backUpReportList = [];
+      $scope.deviceDetector = deviceDetector;
+
+      /** @method onEditInit()
+       * @param storeReport
+       * This method is called once user choose to edit order name using right swipe
+       */
+      $scope.onEditInit = function(storeReport) {
+        angular.element(document.querySelector('#order-name-input'))[0].focus();
+        var shoppinPalMainDiv = angular.element(document.querySelector('.shoppinPal-warehouse'));
+        if($scope.deviceDetector.isDesktop()) {
+          shoppinPalMainDiv.bind('mousedown', function(event) {
+            if( !event.target.classList.contains('editable-panel') ) {
+              $scope.dismissEdit(storeReport);
+              shoppinPalMainDiv.unbind('mousedown');
+            }
+          });
+        } else {
+          shoppinPalMainDiv.bind('touchstart', function(event) {
+            if( !event.target.classList.contains('editable-panel') ) {
+              $scope.dismissEdit(storeReport);
+              shoppinPalMainDiv.unbind('touchstart');
+            }
+          });
+        }
+      };
 
       /** @method editOrder
        * This will edit the order name

--- a/client/app/scripts/controllers/store-report-manager.js
+++ b/client/app/scripts/controllers/store-report-manager.js
@@ -99,7 +99,7 @@ angular.module('ShoppinPalApp')
         // Q: why not use the SKU field as the id?
         // A: BECAUSE many other reports may have the same product and if we do this
         //    then entries will nuke each other in the table
-        $scope.waitOnMarkCompletePromise = StockOrderLineitemModel.prototype$updateAttributes(
+        $scope.waitOnPromise = StockOrderLineitemModel.prototype$updateAttributes(
           { id: storeReportRow.id },
           {
             state: 'complete'

--- a/client/app/views/store-landing.html
+++ b/client/app/views/store-landing.html
@@ -84,14 +84,15 @@
                                     <td width="5%">{{storeReport.totalRows}}</td>
                                 </tr>
                                 <!-- Edit store-report start -->
-                                <tr ng-if="$index==selectedRowIndex"
-                                    ng-mouseleave="dismissEdit(storeReport)"
-                                    class="edit-row">
-                                    <td colspan="6">
-                                        <div class="col-sm-2">{{storeReport.id}}</div>
-                                        <div class="col-sm-3">
+                                <!--<tr ng-if="$index==selectedRowIndex" ng-mouseleave="dismissEdit(storeReport)" class="edit-row">-->
+                                <tr ng-if="$index==selectedRowIndex" class="edit-row editable-panel"
+                                    ng-init="onEditInit(storeReport)">
+                                    <td colspan="6" class="editable-panel">
+                                        <div class="col-sm-2 editable-panel">{{storeReport.id}}</div>
+                                        <div class="col-sm-3 editable-panel">
                                             <input type="text"
-                                                   class="form-control store-landing-outlet-input"
+                                                   id="order-name-input"
+                                                   class="form-control store-landing-outlet-input editable-panel"
                                                    ng-model="storeReport.name">
                                         </div>
                                     </td>

--- a/client/app/views/store-report-manager.html
+++ b/client/app/views/store-report-manager.html
@@ -42,7 +42,7 @@
     <div class="row main-container">
         <div class="inner-container">
             <div class="report-manager-ipad-search">
-                <h4 class="jumpto">Jump to</h4>
+                <h4 class="jumpto" ng-if="displayPendingRows">Jump to</h4>
                 <ul ng-if="displayPendingRows"
                     class="store-auto-height">
                     <li ng-repeat="value in alphabets | unique:'value'">
@@ -50,7 +50,8 @@
                     </li>
                 </ul>
             </div>
-            <div class="center-block" cg-busy="waitOnMarkCompletePromise">
+            <!--<div class="center-block" cg-busy="waitOnMarkCompletePromise">-->
+            <div class="center-block">
                 <div class="report-manager-ipad-scroll">
                     <table cellspacing="0" cellpadding="0" width="100%" class="table table-responsive store-landing-right-table">
                         <thead>


### PR DESCRIPTION
Hi @pulkitsinghal , I have fixed Issue #90 , and along with that I have removed the "Jump to" text from "Show Completed" section on the store-report-manager page as we do not have categories there. I had to remove "cg-busy" from the report table's parent div because it was adding "position:relative" style to it which was breaking the Category navigation, please review, thanks.
cc @srisub 