### PR TITLE
Fixed Issue#120, completed reports are always sorted towards bottom within the supplier group

### DIFF
--- a/client/app/views/store-landing.html
+++ b/client/app/views/store-landing.html
@@ -40,7 +40,7 @@
                     </table>
                     <div class="scrollable-table">
                         <table cellspacing="0" cellpadding="0" width="100%" class="table table-responsive store-landing-right-table">
-                            <tbody ng-repeat="storeReport in reportLists| orderBy:'supplier.name'| groupBy: 'supplier.name'">
+                            <tbody ng-repeat="storeReport in reportLists| orderBy:['supplier.name', '-state', 'name']| groupBy: 'supplier.name'">
                                 <tr ng-if="storeReport.group_by_CHANGED"
                                     id="jumpto{{storeReport.supplier.name}}"
                                     class="inner-table-heading">


### PR DESCRIPTION
Hi @pulkitsinghal , this is the simplest approach which I could think for issue #120 , however this will fail if we have a state starting with 'a' or 'b', please let me know if I need to take another approach for fixing this, thanks.
cc @srisub 