### PR TITLE
Added 'Show More' feature for store-landing page

### DIFF
--- a/client/app/styles/content.css
+++ b/client/app/styles/content.css
@@ -539,11 +539,18 @@ p.note-text{
     visibility: hidden;
 }
 .show-more-link{
+    cursor: pointer;
     color: #442861;
     text-transform:capitalize;
+    font-weight: 600;
 }
 .show-more-link:hover{
     color: #2d8d5a;
+}
+.show-more-link.disabled{
+    pointer-events: none;
+    cursor: default;
+    color: #999999
 }
 .tr-even{
     background:#eaf9fc;
@@ -1306,4 +1313,9 @@ background-color: #E0E0E0;
     color: #21639d !important;
     background-color: #ffffff !important;
     border: 3px solid !important;
+}
+
+.show-more-container {
+    text-align: right !important;
+    padding: 10px;
 }

--- a/client/app/views/store-landing.html
+++ b/client/app/views/store-landing.html
@@ -33,7 +33,7 @@
             <div class="report-manager-ipad-search">
                 <h4 class="jumpto">Jump To<br>Supplier</h4>
                 <ul class="store-auto-height">
-                    <li ng-repeat="store in reportLists | orderBy:'supplier.name' | unique:'supplier.name'">
+                    <li ng-repeat="store in filteredLists | orderBy:'supplier.name' | unique:'supplier.name'">
                         <a href="" ng-click="gotoDepartment(store.supplier.name)">{{store.supplier.name}}</a>
                     </li>
                 </ul>
@@ -52,11 +52,20 @@
                     </table>
                     <div class="scrollable-table">
                         <table cellspacing="0" cellpadding="0" width="100%" class="table table-responsive store-landing-right-table">
-                            <tbody ng-repeat="storeReport in reportLists| orderBy:['supplier.name', '-state', 'name']| groupBy: 'supplier.name'">
+                            <tbody ng-repeat="storeReport in filteredLists | orderBy:['supplier.name', '-state', 'name']| groupBy: 'supplier.name'">
                                 <tr ng-if="storeReport.group_by_CHANGED"
                                     id="jumpto{{storeReport.supplier.name}}"
                                     class="inner-table-heading">
-                                    <td colspan="5"><span class="table-heading-font">{{storeReport.supplier.name}}</span></td>
+                                    <td colspan="3"><span class="table-heading-font">{{storeReport.supplier.name}}</span></td>
+                                    <td colspan="1">
+                                        <div class="show-more-container">
+                                            <a class="show-more-link"
+                                                ng-click="showMore(storeReport.supplier.name)"
+                                                ng-class="{'disabled': !supplierWiseListSize[storeReport.supplier.name].enabled}">
+                                                Show More...
+                                            </a>
+                                        </div>
+                                    </td>
                                 </tr>
                                 <tr ng-if="$index!==selectedRowIndex"
                                     ng-click="drilldownToReport($index, storeReport)"


### PR DESCRIPTION
Added 'Show More' feature (Fixed Issue #121) for store-landing page.
- On page load, shows 5 records per supplier.
- Clicking on Show more link loads next 5 records for the supplier.
- If there is no more item to show for a specific supplier, Show more link gets disabled (Should we hide it ?)
- TODO: Implementation for warehouse-landing page.
cc @pulkitsinghal @srisub 