### PR TITLE
Improve documentation and automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,81 @@
+# AWS account credentials
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+##
+# A seed file contains information to populate the database. It contains:
+# - roles, usernames, passwords
+# - integration tokens gained via a successful oauth handshake,
+#   used to communicate with a point-of-sale (Vend) on behalf of retailers
+# - suppliers, outlets
+# - anything and everything which we cannot add via a UI for onboarding warehouse users
+##
+
+# location of the seed file
+AWS_BUCKET=
+AWS_DEFAULT_REGION=
+AWS_KEY=
+
+##
+# Warehouse sends jobs/payloads to a queue so that a worker may pick them up and finish them off.
+# There are many technologies that can provide a queue implementation: SQS, RabbitMQ, redis, etc.
+##
+
+# location of the queue and credentials to access it
+AWS_SQS_ACCESS_KEY_ID=
+AWS_SQS_REGION=
+AWS_SQS_SECRET_ACCESS_KEY=
+AWS_SQS_URL=
+
+##
+# Each worker takes care of a different task.
+# Sometimes workers are renamed, so in order to avoid code changes,
+# those worker names can be configured here, instead.
+##
+
+# DO NOT TOUCH - unless you are a developer
+GENERATE_STOCK_ORDER_WORKER=generateStockOrderSeriallyWithPaging
+IMPORT_STOCK_ORDER_TO_POS=addProductsToVendConsignment
+IMPORT_STOCK_ORDER_TO_WAREHOUSE=wh.order.import.cached
+IMPORT_STOCK_ORDER_TO_WAREHOUSE_WITHOUT_SUPPLIER=wh.order.import.cached.excel.without.supplier
+REMOVE_UNFULFILLED_PRODUCTS_WORKER=removeUnfulfilledProductsFromStockOrder
+REMOVE_UNRECEIVED_PRODUCTS_WORKER=removeUnreceivedProductsFromStockOrder
+STOCK_ORDER_WORKER=generateStockOrder
+
+# valid values are local or staging or production
+NODE_ENV=local
+
+# TODO: explain
+SCHEME=http
+
+##
+# Whomever is running warehouse, needs to be identified as a unique player by the point-of-sale (Vend)
+# To get these, you can:
+# - Register as a developer or Sign In: https://developers.vendhq.com/
+# - View or Add Application
+#   - https://developers.vendhq.com/developer/applications
+##
+
+# your identification credentials given by Vend
+VEND_CLIENT_ID=
+VEND_CLIENT_SECRET=
+
+##
+# To accomodate redirects, the code needs to know the external facing URL (FQDN or IP)
+##
+VM_EXTERNAL_IP=lb
+
+##
+# Warehouse has evolved over time to work with different Queue and Worker infrastructures:
+# - IronWorker by iron.io
+# - SQS by Amazon Web Services
+#
+# It moved across various solutions due trade-offs between:
+# - cost/resources
+# - stability
+# - high or low devops involvement
+# - ease-of-support
+##
+
+# DO NOT TOUCH - unless you are a developer
+WORKER_TYPE=AWS

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,26 @@
+# Motivation
+
+Automate queues and deadLetter queues setup. This is where the workers pull payloads from.
+
+# How to run
+
+1. Create an `.env` file
+    ```
+    # Must have the appriopriate IAM permissions to manipulate SQS
+    AWS_ACCESS_KEY_ID=<fill it in>
+    AWS_SECRET_ACCESS_KEY=<fill it in>
+    ```
+1. Run `. ./setenv.sh`
+2. Think of a name for your queue (`Q`) and your deadLetter queue (`DLQ`) based on the environment (`dev/local`, `staging`, `prod`) you are acting in, then:
+    * `cd terraform`
+    * `terraform plan -out plan.tfplan`
+    * `terraform apply plan.tfplan`
+    * For more details, refer to the inline comments in `terraform/main.tf`
+
+# Challenges
+
+The [warehouse-workers](https://github.com/ShoppinPal/warehouse-workers) project is meant to work in tandem with [warehouse](https://github.com/ShoppinPal/warehouse) which means that the current implementation lacks the following features:
+
+1. Both `warehouse-workers` and `warehouse` should be provisioned and deployed via terraform
+1. The provisioned Q should be automatically added to the environment variables for a `warehouse-workers` deployment
+1. The provisioned Q should be automatically added to the environment variables for the corresponding [warehouse](https://github.com/ShoppinPal/warehouse) deployment

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,77 @@
+/*
+  Commands that can be run:
+
+  * Planning stage:
+      * Simple example:
+        ```
+        terraform plan
+        ```
+      * Configurable example:
+        ```
+        terraform plan \
+          -var 'Q=pulkit-dev-warehouse-workers-Q' \
+          -var 'DLQ=pulkit-dev-warehouse-workers-DLQ'
+        ```
+      * [Recommended] Configurable & Predictable example:
+        ```
+        # dev env
+        terraform plan \
+          -var 'Q=YOUR_FIRST_NAME-dev-warehouse-workers-Q' \
+          -var 'DLQ=YOUR_FIRST_NAME-dev-warehouse-workers-DLQ' \
+          -out plan.tfplan
+        # staging env
+        terraform plan \
+          -var 'Q=staging-warehouse-workers-Q' \
+          -var 'DLQ=staging-warehouse-workers-DLQ' \
+          -out plan.tfplan
+        # production env
+        terraform plan \
+          -var 'Q=warehouse-workers-Q' \
+          -var 'DLQ=warehouse-workers-DLQ' \
+          -out plan.tfplan
+        ```
+  * Execution stage:
+      * Simple example:
+        ```
+        terraform apply
+        ```
+      * [Recommended] Predictable example:
+        ```
+        terraform apply plan.tfplan
+        ```
+  * Destruction stage:
+    ```
+    terraform destroy
+    ```
+*/
+
+provider "aws" {
+  # WARNING: FIFO queues are only available in two regions
+  #          currently: us-east-2 and us-west-2
+  region = "us-west-2"
+}
+
+resource "aws_sqs_queue" "warehouse_workers_DLQ" {
+  #name                        = "warehouse-workers-DLQ"
+  name                        = "${var.DLQ}"
+  content_based_deduplication = false,
+  delay_seconds               = 0,
+  fifo_queue                  = false,
+  max_message_size            = 262144,
+  message_retention_seconds   = 1209600,
+  receive_wait_time_seconds   = 0,
+  visibility_timeout_seconds  = 30
+}
+
+resource "aws_sqs_queue" "warehouse_workers_Q" {
+  #name                        = "warehouse-workers-Q",
+  name                        = "${var.Q}"
+  content_based_deduplication = false,
+  delay_seconds               = 0,
+  fifo_queue                  = false,
+  max_message_size            = 262144,
+  message_retention_seconds   = 1209600,
+  receive_wait_time_seconds   = 10,
+  redrive_policy              = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.warehouse_workers_DLQ.arn}\",\"maxReceiveCount\":1}",
+  visibility_timeout_seconds  = "1800" 
+}

--- a/terraform/setenv.sh
+++ b/terraform/setenv.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# This script is used to read the .env file and setup the enviroment variables for local testing
+
+echo "###"
+echo Its best to invoke this script as: '. ./setenv.sh' rather than './setenv.sh'
+echo "###"
+
+while read kv
+do
+    key=${kv%%=*}
+    val=${kv#*=}
+    echo export $key="$val"
+    export $key="$val"
+done < ".env"
+
+echo "###"
+echo Its best to invoke this script as: '. ./setenv.sh' rather than './setenv.sh'
+echo "###"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,2 @@
+variable "Q" {}
+variable "DLQ" {}


### PR DESCRIPTION
## Goals

1. Both `warehouse-workers` and `warehouse` should be provisioned and deployed via terraform
1. The provisioned Q should be automatically added to the environment variables for a `warehouse-workers` deployment
1. The provisioned Q should be automatically added to the environment variables for the corresponding [warehouse](https://github.com/ShoppinPal/warehouse) deployment

## Footnotes

1. Maybe be we can get rid of `setenv.sh` as `.env` can be directly processed by `docker-compose.yml`?