### PR TITLE
add a healthcheck for `web` service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY . /apps/warehouse
 RUN ../node_modules/bower/bin/bower --allow-root install
 ENV SCHEME=http
 ENV DEBUG=shoppinpal:*,boot:*,common:models:*,server:*
+HEALTHCHECK --interval=1m --timeout=3s ----start-period=1m CMD curl -f http://localhost:3000/api/StoreModels || exit 1
 ENTRYPOINT [ "./docker-entrypoint.sh" ]
 EXPOSE 3000
 CMD [ "node","server/server.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.1"
 services:
   nodejs:
     image: node:0.10.48
@@ -43,6 +43,13 @@ services:
       - ./server:/apps/warehouse/server
       - ./package.json:/apps/warehouse/package.json
       - ./npm-shrinkwrap.json:/apps/warehouse/npm-shrinkwrap.json
+    depends_on:
+      - db
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://web:3000/api/StoreModels"]
+      interval: 15s
+      timeout: 10s
+      retries: 3
   worker-web:
     build: .
     ports:
@@ -62,6 +69,7 @@ services:
       - ./docker-entrypoint.sh:/docker-entrypoint.sh
     depends_on:
       - web
+      - db
   worker:
     build:
       context: ./warehouse-workers


### PR DESCRIPTION
iOS devices and desktop browsers reach the api server via `lb-service > nginx > web-service > loopback` and this leaves room for a sticky session where clients/browsers do not failover to other containers when one fails.

Adding healthcheck should help the `web-service` avoid this situation.

I've considered the fact that currently our loopback api server is configured in a way such that it can be ready to serve requests before its boot-phase initialization is complete ... this is worrisome because such a situation can give us a false-positive during a healthcheck ... it can make us think that a container is ready when it isn't.

Hopefully I've got the interval, timeouts and retries tweaked just right to avoid such a false positive. Yes I know that's horrible as I'm counting on knowing how powerful each of my machines is and how much time it takes to come up/down etc.

@harshadyeola - please try it on staging and production and if it doesn't work then tweak or reject as you best see fit.