### PR TITLE
upgrade to node 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10.48
+FROM node:6.11.1
 RUN apt-get -y update && apt-get -y dist-upgrade
 RUN chown -R node:node /usr/local
 RUN apt-get -y update && apt-get -y dist-upgrade && apt-get install -y python-pip python-dev && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.1"
 services:
   nodejs:
-    image: node:0.10.48
+    image: node:6.11.1
     working_dir: /apps/warehouse
     volumes:
       - .:/apps/warehouse
@@ -21,7 +21,7 @@ services:
     # https://github.com/nginxinc/docker-nginx/blob/7e278fff2f12f852ef1be2aed17e9a2f822365ac/stable/stretch/Dockerfile#L43
     # CMD ["nginx", "-g", "daemon off;"]
     #
-    # 2. the nginx image dosn't have `nc` (netcat) or `curl` so we can't use the `wait-for` script
+    # 2. the nginx image doesn't have `nc` (netcat) or `curl` so we can't use the `wait-for` script
     ###
     #command: ["/wait/wait-for", "web:3000", "--", "nginx", "-g", "daemon off;"]
   web:

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "wd-bridge": "0.0.2"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "6.11.1"
   },
   "scripts": {
     "postinstall": "echo -n $NODE_ENV | grep -v 'production' && ./node_modules/protractor/bin/webdriver-manager update || echo 'will NOT run webdriver install or update'"


### PR DESCRIPTION
after much research and deliberation about nodejs profiling, i've reached the conclusion that we should try to upgrade one running container to use nodev6

- if it crashes a lot less than its sibling then we've given ourselves a boost by upgrading to a more efficient nodejs version
- if it continues to crash then:
  - at least a quick reroute (apply healthcheck PR first) to other `web` containers is available
  - and v6 has better support for node profiling baked into it so we can start making use of that to collect some heapdumps for analysis

@harshadyeola please let me know your thoughts on the matter ... i am suggesting this because i won't have e2e tests ready for stress testing warehouse locally for quite some time