### PR TITLE
Env variables to determine path and filename for logging sqs message

### DIFF
--- a/worker.env.example
+++ b/worker.env.example
@@ -11,6 +11,12 @@ AWS_SQS_URL=
 AWS_SQS_ACCESS_KEY_ID=
 AWS_SQS_SECRET_ACCESS_KEY=
 
+# Log message Id to a local file
+# Set SQS_MESSAGE_FILE_PATH=root to generate a file inside project root
+# Set SQS_MESSAGE_FILE_PATH=/dir1/dir2/... will generate the folder structure inside project root
+SQS_MESSAGE_FILE_PATH=root
+SQS_MESSAGE_FILE=sqs-message-id.txt
+
 # cache is used when we want to:
 # - limit the memory consumed by workers
 # - reuse common data across multiple worker runs


### PR DESCRIPTION
Updated example.env for specifying `path` and `filename` to create a file to log sqs message id